### PR TITLE
Configuration and Getting Started link issues

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -124,7 +124,7 @@ or LDAP server setup. If you wish to use a local OpenLDAP instance, follow the
 [Using OpenLDAP for Authentication](./development.html#oldap) guide.
 
 The configuration file format and available parameters described in the
-[Configuration](./configuration.html) document.
+[Configuration](../configuration.html) document.
 
 ### Step 3. Start the Concord Server
 
@@ -193,7 +193,7 @@ Try logging in using your AD/LDAP credentials.
 ## First Project
 
 As a next step you can create your first project as detailed in the
-[quickstart guide](./quickstart.html).
+[quickstart guide](../quickstart.html).
 
 
 ## Clean Up


### PR DESCRIPTION
Configuration and Getting Started links if "Installation using Docker" is followed result in 404 errors.
I've modified relative path "./" to up one directory "../" which resolve this issue.